### PR TITLE
Update Alaz version to v0.1.3

### DIFF
--- a/resources/alaz.yaml
+++ b/resources/alaz.yaml
@@ -74,7 +74,7 @@ spec:
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*)$
-        image: ddosify/alaz:v0.1.2
+        image: ddosify/alaz:v0.1.3
         imagePullPolicy: IfNotPresent
         name: alaz-pod
         ports:


### PR DESCRIPTION
Fix error 'Failed to pull image "ddosify/alaz:v0.1.2"'

![imagen](https://github.com/ddosify/alaz/assets/72597896/ede11589-d6e8-4a12-af36-0e06c11168e9)
