### PR TITLE
clear zombie http2 workers

### DIFF
--- a/aggregator/data.go
+++ b/aggregator/data.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/ddosify/alaz/datastore"
@@ -182,6 +183,42 @@ func (a *Aggregator) Run() {
 		}
 
 	}()
+	go func() {
+		// every 5 minutes, check alive processes, and clear the ones left behind
+		// since we process events concurrently, some short-lived processes exit event can come before exec events
+		// this causes zombie http2 workers
+
+		t := time.NewTicker(5 * time.Minute)
+		defer t.Stop()
+
+		for range t.C {
+			a.liveProcessesMu.Lock()
+
+			for pid, _ := range a.liveProcesses {
+				// https://man7.org/linux/man-pages/man2/kill.2.html
+				//    If sig is 0, then no signal is sent, but existence and permission
+				//    checks are still performed; this can be used to check for the
+				//    existence of a process ID or process group ID that the caller is
+				//    permitted to signal.
+
+				err := syscall.Kill(int(pid), 0)
+				if err != nil {
+					// pid does not exist
+					log.Logger.Warn().Uint32("pid", pid).Msg("clean leftover pid")
+					delete(a.liveProcesses, pid)
+
+					a.clusterInfo.mu.Lock()
+					delete(a.clusterInfo.PidToSocketMap, pid)
+					a.clusterInfo.mu.Unlock()
+
+					// close http2Worker if exist
+					a.stopHttp2Worker(pid)
+				}
+			}
+
+			a.liveProcessesMu.Unlock()
+		}
+	}()
 	go a.processk8s()
 
 	numWorker := 100
@@ -234,28 +271,17 @@ func (a *Aggregator) processEbpf(ctx context.Context) {
 			}
 			switch bpfEvent.Type() {
 			case tcp_state.TCP_CONNECT_EVENT:
-				d := data.(tcp_state.TcpConnectEvent) // copy data's value
-				tcpConnectEvent := tcp_state.TcpConnectEvent{
-					Fd:        d.Fd,
-					Timestamp: d.Timestamp,
-					Type_:     d.Type_,
-					Pid:       d.Pid,
-					SPort:     d.SPort,
-					DPort:     d.DPort,
-					SAddr:     d.SAddr,
-					DAddr:     d.DAddr,
-				}
-				go a.processTcpConnect(tcpConnectEvent)
+				d := data.(*tcp_state.TcpConnectEvent) // copy data's value
+				go a.processTcpConnect(d)
 			case l7_req.L7_EVENT:
 				d := data.(*l7_req.L7Event) // copy data's value
 				go a.processL7(ctx, d)
 			case proc.PROC_EVENT:
-				d := data.(proc.ProcEvent) // copy data's value
+				d := data.(*proc.ProcEvent) // copy data's value
 				if d.Type_ == proc.EVENT_PROC_EXEC {
 					go a.processExec(d)
 				} else if d.Type_ == proc.EVENT_PROC_EXIT {
-					go a.processExit(d)
-					go a.stopHttp2Worker(d.Pid)
+					go a.processExit(d.Pid)
 				}
 			}
 
@@ -263,16 +289,23 @@ func (a *Aggregator) processEbpf(ctx context.Context) {
 	}
 }
 
-func (a *Aggregator) processExec(d proc.ProcEvent) {
+func (a *Aggregator) processExec(d *proc.ProcEvent) {
 	a.liveProcessesMu.Lock()
 	a.liveProcesses[d.Pid] = struct{}{}
 	a.liveProcessesMu.Unlock()
 }
 
-func (a *Aggregator) processExit(d proc.ProcEvent) {
+func (a *Aggregator) processExit(pid uint32) {
 	a.liveProcessesMu.Lock()
-	delete(a.liveProcesses, d.Pid)
+	delete(a.liveProcesses, pid)
 	a.liveProcessesMu.Unlock()
+
+	a.clusterInfo.mu.Lock()
+	delete(a.clusterInfo.PidToSocketMap, pid)
+	a.clusterInfo.mu.Unlock()
+
+	// close http2Worker if exist
+	a.stopHttp2Worker(pid)
 }
 
 func (a *Aggregator) stopHttp2Worker(pid uint32) {
@@ -297,8 +330,7 @@ func (a *Aggregator) stopHttp2Worker(pid uint32) {
 	}
 }
 
-func (a *Aggregator) processTcpConnect(data interface{}) {
-	d := data.(tcp_state.TcpConnectEvent)
+func (a *Aggregator) processTcpConnect(d *tcp_state.TcpConnectEvent) {
 	go a.ec.ListenForEncryptedReqs(d.Pid)
 	if d.Type_ == tcp_state.EVENT_TCP_ESTABLISHED {
 		// filter out localhost connections

--- a/aggregator/sock_num_line.go
+++ b/aggregator/sock_num_line.go
@@ -111,7 +111,7 @@ func (nl *SocketLine) DeleteUnused() {
 	}
 
 	// assumedInterval is inversely proportional to the number of requests being discarded
-	assumedInterval := uint64(5 * time.Minute)
+	assumedInterval := uint64(3 * time.Minute)
 
 	// delete all values that
 	// closed and its LastMatch + assumedInterval < lastMatchedReqTime

--- a/ebpf/proc/main.go
+++ b/ebpf/proc/main.go
@@ -126,7 +126,7 @@ func DeployAndWait(parentCtx context.Context, ch chan interface{}) {
 				bpfEvent := (*PEvent)(unsafe.Pointer(&record.RawSample[0]))
 
 				go func() {
-					ch <- ProcEvent{
+					ch <- &ProcEvent{
 						Pid:   bpfEvent.Pid,
 						Type_: ProcEventConversion(bpfEvent.Type_).String(),
 					}

--- a/ebpf/tcp_state/main.go
+++ b/ebpf/tcp_state/main.go
@@ -178,7 +178,7 @@ func DeployAndWait(parentCtx context.Context, ch chan interface{}) {
 				bpfEvent := (*TcpEvent)(unsafe.Pointer(&record.RawSample[0]))
 
 				go func() {
-					ch <- TcpConnectEvent{
+					ch <- &TcpConnectEvent{
 						Pid:       bpfEvent.Pid,
 						Fd:        bpfEvent.Fd,
 						Timestamp: bpfEvent.Timestamp,


### PR DESCRIPTION
- clear http2 workers that's been started after process exit cause of concurrency.
- pass around pointers to optimize memory at some func calls.