### PR TITLE
fix seq num check on tcp_sock

### DIFF
--- a/ebpf/l7_req/l7.c
+++ b/ebpf/l7_req/l7.c
@@ -501,7 +501,7 @@ int process_exit_of_syscalls_read_recvfrom(void* ctx, __u64 id, __u32 pid, __s64
         e->pid = k.pid;
 
         // for distributed tracing
-        e->seq = 0; // default value , TODO : ?
+        e->seq = 0; // default value
         e->tid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
 
         // reset payload

--- a/ebpf/l7_req/tcp_sock.c
+++ b/ebpf/l7_req/tcp_sock.c
@@ -146,6 +146,9 @@ __u64 process_for_dist_trace_write(void* ctx, __u64 fd){
     tid = (__u32)id;
 
     __u32 seq = get_tcp_write_seq_from_fd(fd);
+    if(seq == 0){
+        return 0;
+    }
 
     int zero = 0;
     struct call_event *e = bpf_map_lookup_elem(&ingress_egress_heap, &zero);
@@ -175,6 +178,9 @@ void process_for_dist_trace_read(void* ctx, __u32 fd){
     tid = (__u32)id;
 
     __u32 seq = get_tcp_copied_seq_from_fd(fd);
+    if(seq == 0){
+        return;
+    }
 
     int zero = 0;
     struct call_event *e = bpf_map_lookup_elem(&ingress_egress_heap, &zero);


### PR DESCRIPTION
- If we are unable to fetch a tcp_sock from a file descriptor, do not send traffic data.