### PR TITLE
Refactor/speed up

### DIFF
--- a/ebpf/collector.go
+++ b/ebpf/collector.go
@@ -72,7 +72,7 @@ func NewEbpfCollector(parentCtx context.Context) *EbpfCollector {
 		ctx:                 ctx,
 		done:                make(chan struct{}),
 		ebpfEvents:          make(chan interface{}, 100000), // interface is 16 bytes, 16 * 100000 = 8 Megabytes
-		ebpfProcEvents:      make(chan interface{}, 100),
+		ebpfProcEvents:      make(chan interface{}, 2000),
 		ebpfTcpEvents:       make(chan interface{}, 1000),
 		tlsPidMap:           make(map[uint32]struct{}),
 		sslWriteUprobes:     make(map[uint32]link.Link),

--- a/main.go
+++ b/main.go
@@ -72,11 +72,12 @@ func main() {
 	var ec *ebpf.EbpfCollector
 	if ebpfEnabled {
 		ec = ebpf.NewEbpfCollector(ctx)
-		ec.Init()
-		go ec.ListenEvents()
 
 		a := aggregator.NewAggregator(ctx, kubeEvents, ec.EbpfEvents(), ec.EbpfProcEvents(), ec.EbpfTcpEvents(), ec.TlsAttachQueue(), dsBackend)
 		a.Run()
+
+		ec.Init()
+		go ec.ListenEvents()
 	}
 
 	go http.ListenAndServe(":8181", nil)


### PR DESCRIPTION
- Speed up workers by getting rid of lock contention on accessing socketMap to corresponding pid.
- Use an array of **pid_max** len to represent socket maps