### PR TITLE
refactor log event processing

### DIFF
--- a/ebpf/l7_req/l7.go
+++ b/ebpf/l7_req/l7.go
@@ -579,7 +579,16 @@ func (l7p *L7Prog) Consume(ctx context.Context, ch chan interface{}) {
 			}
 
 			go func(l7Event *L7Event) {
-				ch <- l7Event
+				select {
+				case ch <- l7Event:
+				default:
+					log.Logger.Warn().
+						Str("protocol", l7Event.Protocol).
+						Str("method", l7Event.Method).
+						Uint32("pid", l7Event.Pid).
+						Uint32("status", l7Event.Status).
+						Msg("channel full, dropping l7 event")
+				}
 			}(userspacel7Event)
 		}
 		for {

--- a/resources/alaz.yaml
+++ b/resources/alaz.yaml
@@ -20,6 +20,7 @@ rules:
   - replicasets
   - deployments
   - daemonsets
+  - statefulsets
   verbs:
   - "get"
   - "list"


### PR DESCRIPTION
- discard some frequent events belong to a distinct container in order to consume faster from inotify queue to prevent buffer overflow.
- skipped events are processed periodically and remaining logs are flushed.